### PR TITLE
feat: implement infinite scrolling for TagList & another fix

### DIFF
--- a/components/TagList.tsx
+++ b/components/TagList.tsx
@@ -68,59 +68,61 @@ export default function TagList({
     <div className="border p-4 rounded">
       <p className="text-lg font-semibold mb-4">Tags ({tags.length})</p>
 
-      {tagsQuery.status === 'pending' && <p>Loading tags...</p>}
+      {/* Filter tags */}
+      <Input
+        type="text"
+        placeholder="Filter tags"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value.toLowerCase())}
+        className="w-full p-2 border rounded my-4"
+      />
 
-      {tagsQuery.status === 'error' && (
-        <p className="text-destructive">{tagsQuery.error.message}</p>
-      )}
+      <ScrollArea className="mt-2 max-h-[10rem] lg:max-h-[16rem] overflow-y-auto">
+        <ul className="space-y-2">
+          {filteredTags.map((tag) => (
+            <li key={tag.name}>
+              <Button
+                variant={tag.name === selectedTag?.name ? 'default' : 'outline'}
+                onClick={() => {
+                  onTagSelect?.(tag)
+                }}
+                className="w-full truncate"
+              >
+                {tag.name}
+              </Button>
+            </li>
+          ))}
 
-      {tagsQuery.status === 'success' && (
-        <>
-          {/* Filter tags */}
-          <Input
-            type="text"
-            placeholder="Filter tags"
-            value={filter}
-            onChange={(e) => setFilter(e.target.value.toLowerCase())}
-            className="w-full p-2 border rounded my-4"
-          />
-
-          <ScrollArea className="mt-2 max-h-[10rem] lg:max-h-[16rem] overflow-y-auto">
-            <ul className="space-y-2">
-              {filteredTags.map((tag) => (
-                <li key={tag.name}>
-                  <Button
-                    variant={
-                      tag.name === selectedTag?.name ? 'default' : 'outline'
-                    }
-                    onClick={() => {
-                      onTagSelect?.(tag)
-                    }}
-                    className="w-full truncate"
-                  >
-                    {tag.name}
-                  </Button>
-                </li>
-              ))}
-              {tagsQuery.hasNextPage && (
-                <div ref={observerTarget} className="h-6">
-                  {tagsQuery.isFetchingNextPage && (
-                    <LoaderIcon className="animate-spin h-6 w-6 mx-auto">
-                      <span className="sr-only">Loading...</span>
-                    </LoaderIcon>
-                  )}
-                </div>
+          {/* Load more */}
+          {tagsQuery.hasNextPage && (
+            <div ref={observerTarget} className="h-6">
+              {tagsQuery.isFetchingNextPage && (
+                <LoaderIcon className="animate-spin h-6 w-6 mx-auto">
+                  <span className="sr-only">Loading...</span>
+                </LoaderIcon>
               )}
-            </ul>
+            </div>
+          )}
+        </ul>
+      </ScrollArea>
 
-            {!tagsQuery.hasNextPage && filteredTags.length === 0 && (
-              <p className="text-center text-gray-500">
-                No tags found. Try a different filter.
-              </p>
-            )}
-          </ScrollArea>
-        </>
+      {tagsQuery.isPending && (
+        <p className="text-center text-sm mt-2">Loading tags...</p>
       )}
+
+      {tagsQuery.isError && (
+        <p className="text-destructive text-center text-sm mt-2">
+          {tagsQuery.error.message}
+        </p>
+      )}
+
+      {tagsQuery.isSuccess &&
+        !tagsQuery.hasNextPage &&
+        filteredTags.length < 1 && (
+          <p className="text-center text-gray-500 dark:text-gray-400 text-sm mt-2">
+            No tags found. Try a different filter.
+          </p>
+        )}
     </div>
   )
 }

--- a/components/TagList.tsx
+++ b/components/TagList.tsx
@@ -33,7 +33,10 @@ export default function TagList({
     },
   })
 
-  const tags = tagsQuery.data?.pages.flat() ?? []
+  const tags = useMemo(() => {
+    return tagsQuery.data?.pages?.flat() ?? []
+  }, [tagsQuery.data])
+
   const filteredTags = useMemo(() => {
     return tags.filter((tag) => tag.name.includes(filter))
   }, [tags, filter])

--- a/components/TagList.tsx
+++ b/components/TagList.tsx
@@ -3,7 +3,8 @@
 import { MAX_ITEMS_PER_PAGE, type Tag, getTags } from '@/lib/github'
 import { ScrollArea } from '@radix-ui/react-scroll-area'
 import { useInfiniteQuery } from '@tanstack/react-query'
-import { useState } from 'react'
+import { LoaderIcon } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Button } from './ui/button'
 import { Input } from './ui/input'
 
@@ -33,7 +34,32 @@ export default function TagList({
   })
 
   const tags = tagsQuery.data?.pages.flat() ?? []
-  const filteredTags = tags.filter((tag) => tag.name.includes(filter))
+  const filteredTags = useMemo(() => {
+    return tags.filter((tag) => tag.name.includes(filter))
+  }, [tags, filter])
+
+  const observerTarget = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (
+          entries[0].isIntersecting &&
+          tagsQuery.hasNextPage &&
+          !tagsQuery.isFetchingNextPage
+        ) {
+          fetchNextPage()
+        }
+      },
+      { threshold: 0.5 },
+    )
+
+    if (observerTarget.current) {
+      observer.observe(observerTarget.current)
+    }
+
+    return () => observer.disconnect()
+  }, [fetchNextPage, tagsQuery.hasNextPage, tagsQuery.isFetchingNextPage])
 
   return (
     <div className="border p-4 rounded">
@@ -52,43 +78,42 @@ export default function TagList({
             type="text"
             placeholder="Filter tags"
             value={filter}
-            onChange={(e) => setFilter(e.target.value)}
+            onChange={(e) => setFilter(e.target.value.toLowerCase())}
             className="w-full p-2 border rounded my-4"
           />
 
-          <ScrollArea className="mt-2 max-h-[10rem] lg:max-h-[60vh] overflow-y-auto">
-            {filteredTags.length > 0 ? (
-              <ul className="space-y-2">
-                {filteredTags.map((tag) => (
-                  <li key={tag.name}>
-                    <Button
-                      variant={tag === selectedTag ? 'default' : 'outline'}
-                      onClick={() => {
-                        onTagSelect?.(tag)
-                      }}
-                      className="w-full"
-                    >
-                      {tag.name}
-                    </Button>
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <p className="text-center my-2 text-gray-500">
-                No tags found. Try a different filter or load more.
-              </p>
-            )}
+          <ScrollArea className="mt-2 max-h-[10rem] lg:max-h-[16rem] overflow-y-auto">
+            <ul className="space-y-2">
+              {filteredTags.map((tag) => (
+                <li key={tag.name}>
+                  <Button
+                    variant={
+                      tag.name === selectedTag?.name ? 'default' : 'outline'
+                    }
+                    onClick={() => {
+                      onTagSelect?.(tag)
+                    }}
+                    className="w-full truncate"
+                  >
+                    {tag.name}
+                  </Button>
+                </li>
+              ))}
+              {tagsQuery.hasNextPage && (
+                <div ref={observerTarget} className="h-6">
+                  {tagsQuery.isFetchingNextPage && (
+                    <LoaderIcon className="animate-spin h-6 w-6 mx-auto">
+                      <span className="sr-only">Loading...</span>
+                    </LoaderIcon>
+                  )}
+                </div>
+              )}
+            </ul>
 
-            {/* Load more */}
-            {tagsQuery.hasNextPage && (
-              <Button
-                variant="secondary"
-                onClick={() => fetchNextPage()}
-                className="w-full mt-2"
-                disabled={tagsQuery.isFetchingNextPage}
-              >
-                {tagsQuery.isFetchingNextPage ? 'Loading...' : 'Load more'}
-              </Button>
+            {!tagsQuery.hasNextPage && filteredTags.length === 0 && (
+              <p className="text-center text-gray-500">
+                No tags found. Try a different filter.
+              </p>
             )}
           </ScrollArea>
         </>

--- a/components/TagList.tsx
+++ b/components/TagList.tsx
@@ -38,7 +38,7 @@ export default function TagList({
   }, [tagsQuery.data])
 
   const filteredTags = useMemo(() => {
-    return tags.filter((tag) => tag.name.includes(filter))
+    return tags.filter((tag) => tag.name.toLowerCase().includes(filter))
   }, [tags, filter])
 
   const observerTarget = useRef<HTMLDivElement>(null)


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] Bug fix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
- The manual "Load More" button for tags is cumbersome and disrupts user experience.
- The Match Tag Selector is non-functional when a `?tag` query parameter is present, e.g., {BASE_URL}/vercel/next.js?tag=v15.0.4.
- On larger screens, the tags container's height exceeds the viewport, requiring users to scroll the page to access the last tag item.
- The search filter is case-sensitive, which can lead to inconsistent filtering behavior and poor usability.

## What is the new behavior?
- Used `useMemo` to memoize the filtered tags list, preventing unnecessary recalculations.
- Added an intersection observer to automatically fetch the next page of tags when the user scrolls near the bottom of the list.
- Modified the tag filter input to convert the filter text to lowercase, making the filter case-insensitive.
- Updated the `ScrollArea` component's max height for better display on larger screens and added a loading spinner for fetching more tags.