### PR TITLE
Make TagList component sticky in large viewport

### DIFF
--- a/components/TagList.tsx
+++ b/components/TagList.tsx
@@ -65,7 +65,7 @@ export default function TagList({
   }, [fetchNextPage, tagsQuery.hasNextPage, tagsQuery.isFetchingNextPage])
 
   return (
-    <div className="border p-4 rounded">
+    <div className="border p-4 rounded lg:sticky lg:top-16 lg:z-20">
       <p className="text-lg font-semibold mb-4">Tags ({tags.length})</p>
 
       {/* Filter tags */}

--- a/components/TagList.tsx
+++ b/components/TagList.tsx
@@ -77,7 +77,7 @@ export default function TagList({
         className="w-full p-2 border rounded my-4"
       />
 
-      <ScrollArea className="mt-2 max-h-[10rem] lg:max-h-[16rem] overflow-y-auto">
+      <ScrollArea className="mt-2 max-h-[10rem] lg:max-h-[20rem] overflow-y-auto">
         <ul className="space-y-2">
           {filteredTags.map((tag) => (
             <li key={tag.name}>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
The `TagList` component scrolls out of view on large screens when the release content is lengthy, making it inconvenient for users to access the tags while scrolling.

## What is the new behavior?
The `TagList` component is now **sticky** on large viewports, ensuring it remains visible and accessible as the user scrolls through the page.

https://github.com/user-attachments/assets/d249e177-2c39-438a-9737-f135ed35c398

