### PR TITLE
fix: update `NEXT_NOT_FOUND_ERR_MSG` after upgrading to `next@15.1`

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -34,7 +34,8 @@ export function debounce<T extends unknown[]>(
   }
 }
 
-export const NEXT_NOT_FOUND_ERR_MSG = 'NEXT_NOT_FOUND'
+// See https://github.com/vercel/next.js/blob/dafcd43/packages/next/src/client/components/not-found.ts#L21
+const NEXT_NOT_FOUND_ERR_MSG = 'NEXT_HTTP_ERROR_FALLBACK;404'
 
 export function isNextNotFoundError(error: unknown) {
   return error instanceof Error && error.message === NEXT_NOT_FOUND_ERR_MSG


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
- `isNextNotFoundError()` can't catch Next [`notFound()`](https://nextjs.org/docs/app/api-reference/functions/not-found) after upgrading to v15.1 

## What is the new behavior?
In v15.1, the `NEXT_NOT_FOUND_ERR_MSG` value has changed:
- v15.1: `'${HTTP_ERROR_FALLBACK_ERROR_CODE};404'` (see [here](https://github.com/vercel/next.js/blob/dafcd43fac3ef9d0ffd94f9c94fd61db4449df25/packages/next/src/client/components/not-found.ts#L21))
- v15.0.4: `'NEXT_NOT_FOUND'` (see [here](https://github.com/vercel/next.js/blob/d6a6aa14069a497728ccb11e5b8acd8bf93e76f1/packages/next/src/client/components/not-found.ts#L1))
