### PR TITLE
fix: prevent linking package names in markdown mentions

### DIFF
--- a/components/ReleaseContent.tsx
+++ b/components/ReleaseContent.tsx
@@ -7,13 +7,29 @@ import dayjs from 'dayjs'
 import { ClockIcon, LinkIcon } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import remarkGithub from 'remark-github'
+import remarkGithub, {
+  defaultBuildUrl,
+  type Options as RemarkGithubOptions,
+} from 'remark-github'
 import { toast } from 'sonner'
 import { Button } from './ui/button'
 
 type Props = {
   repo: string
   tag?: string
+}
+
+const remarkGithubConfig: Readonly<RemarkGithubOptions> = {
+  mentionStrong: false,
+  buildUrl: (values) => {
+    // Don't link package names, e.g. `@types/node`
+    // Github username can't have `/` character
+    if (values.type === 'mention' && values.user.includes('/')) {
+      return false
+    }
+
+    return defaultBuildUrl(values)
+  },
 }
 
 export default function ReleaseContent({ repo, tag }: Props) {
@@ -74,7 +90,13 @@ export default function ReleaseContent({ repo, tag }: Props) {
         className="prose prose-sm dark:prose-invert max-w-none"
         remarkPlugins={[
           remarkGfm,
-          [remarkGithub, { repository: repo, mentionStrong: false }],
+          [
+            remarkGithub,
+            {
+              ...remarkGithubConfig,
+              repository: repo,
+            },
+          ],
         ]}
       >
         {release.body}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [x] I have included the necessary changes to the documentation.
- [x] I have added tests to cover my changes.

## PR Type
What kind of change does this PR introduce?
- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
Before this change, the `remark-github` plugin would try to convert any text that starts with `@` into a GitHub user mention link. This caused issues with npm package names in markdown content, since they often use the `@` prefix but contain forward slashes (e.g., `@types/node`, `@babel/core`).

## What is the new behavior?
The `buildUrl` function in `remarkGithubConfig` now checks for forward slashes
in mention values to avoid treating package names (e.g. @types/node)
as GitHub user mentions.

This improves markdown rendering accuracy by:
- Only linking valid GitHub usernames in mentions
- Preserving package names as plain text

| Before | After |
|---|---|
| ![ss-before](https://github.com/user-attachments/assets/c08e3f66-d1ca-4c86-a399-51d90d17ed15) | ![ss-after](https://github.com/user-attachments/assets/89f94928-aa64-4ae6-b34b-8c9981f1fd5c) |

