### PR TITLE
Improve homepage view

### DIFF
--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -2,14 +2,16 @@ import SearchRepos from '@/components/SearchRepos'
 
 export default function Home() {
   return (
-    <div className="container mx-auto p-4">
-      <h1 className="text-2xl md:text-4xl font-bold my-4 lg:my-6 text-center">
-        GitHub Release Viewer
-      </h1>
-      <p className="text-center text-sm md:text-base mb-6 text-pretty max-w-lg mx-auto">
-        GitHub Release page with <b>better UX</b>. Read and discover GitHub
-        repository release notes with ease.
-      </p>
+    <div className="container mx-auto px-4">
+      <div className="my-10 lg:my-14">
+        <h1 className="text-2xl md:text-4xl mb-4 font-bold text-center">
+          GitHub Release Viewer
+        </h1>
+        <p className="text-center text-sm md:text-base text-pretty mb-2 max-w-lg mx-auto">
+          GitHub Release page with <b>better UX</b>. Read and discover GitHub
+          release notes with ease.
+        </p>
+      </div>
       <SearchRepos />
     </div>
   )

--- a/components/SearchRepos.tsx
+++ b/components/SearchRepos.tsx
@@ -23,8 +23,8 @@ export default function SearchRepos() {
   }, 500)
 
   return (
-    <div className="w-full max-w-2xl mx-auto">
-      <div className="flex flex-col gap-1 mb-4">
+    <div className="w-full">
+      <div className="max-w-2xl mx-auto mb-6 lg:mb-10 flex flex-col gap-1">
         <Input
           type="text"
           placeholder="Search repositories..."
@@ -39,19 +39,19 @@ export default function SearchRepos() {
       </div>
 
       {reposQuery.isError && (
-        <p className="text-destructive">
+        <p className="text-destructive text-center">
           An error occurred: {reposQuery.error.message}
         </p>
       )}
 
       {reposQuery.isSuccess && reposQuery.data.length === 0 && (
-        <p>No repositories found.</p>
+        <p className="text-center">No repositories found.</p>
       )}
 
-      <ul className="space-y-2">
+      <ul className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
         {reposQuery.isLoading &&
-          Array.from({ length: 5 }).map((_, i) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
+          Array.from({ length: 6 }).map((_, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: this is a skeleton
             <Skeleton key={i} className="w-full h-20" />
           ))}
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [x] I have included the necessary changes to the documentation.
- [x] I have added tests to cover my changes.

## PR Type
What kind of change does this PR introduce?
- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
Current homepage is too ugly.

## What is the new behavior?
This pull request includes changes to improve the layout and styling of the `Home` and `SearchRepos` components. The most important changes involve adjusting margins and padding, centering error messages, and modifying the repository list layout.

Improvements to `Home` component layout:

* Adjusted the main container's padding and added a new div for better spacing around the header and description. (`app/(main)/page.tsx`)
* Updated the margins and padding for the header and description to improve visual hierarchy and spacing. (`app/(main)/page.tsx`)

Improvements to `SearchRepos` component layout:

* Modified the container's width and margin settings for better alignment and spacing. (`components/SearchRepos.tsx`)
* Centered the error message text and the "No repositories found" message for better user experience. (`components/SearchRepos.tsx`)
* Changed the repository list layout from a single column to a responsive grid with two columns on larger screens, and adjusted the number of skeleton loaders. (`components/SearchRepos.tsx`)

| Before | After |
|---|---|
| ![ss-before](https://github.com/user-attachments/assets/a2c77fae-9f81-43ac-b288-ac27669cba7a) | ![ss-after](https://github.com/user-attachments/assets/21e12bfa-fb7f-4866-acb5-f6869bffc07a) |
| ![image](https://github.com/user-attachments/assets/a39cf225-73fd-46a2-abd9-08506b7c2e78) | ![image](https://github.com/user-attachments/assets/b57f5631-335b-4f24-8e33-e077d810e5bf) |
