### PR TITLE
feat: display pre-release status badge in release content

### DIFF
--- a/components/ReleaseContent.tsx
+++ b/components/ReleaseContent.tsx
@@ -12,6 +12,7 @@ import remarkGithub, {
   type Options as RemarkGithubOptions,
 } from 'remark-github'
 import { toast } from 'sonner'
+import { Badge } from './ui/badge'
 import { Button } from './ui/button'
 
 type Props = {
@@ -53,7 +54,7 @@ export default function ReleaseContent({ repo, tag }: Props) {
 
   return (
     <>
-      <div className="mb-2 flex gap-2">
+      <div className="mb-2 flex items-center gap-2">
         <p className="text-2xl font-semibold">{release.tag_name}</p>
         <Button
           size={null}
@@ -75,13 +76,15 @@ export default function ReleaseContent({ repo, tag }: Props) {
         </Button>
       </div>
 
-      <div className="flex items-center gap-4">
+      <div className="flex items-center gap-3 flex-wrap">
         <div className="flex gap-2 items-center">
           <ClockIcon className="h-4 w-4" />
           <span className="text-sm">
             {dayjs(release.published_at).format('D MMMM YYYY HH:mm A (Z)')}
           </span>
         </div>
+
+        {release.prerelease && <Badge variant="warning">Pre-release</Badge>}
       </div>
 
       <hr className="mt-4 mb-6" />

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,44 @@
+import { cn } from '@/lib/utils'
+import { Slot } from '@radix-ui/react-slot'
+import { type VariantProps, cva } from 'class-variance-authority'
+import type * as React from 'react'
+
+export const badgeVariants = cva(
+  'inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
+  {
+    variants: {
+      variant: {
+        default:
+          'border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
+        secondary:
+          'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
+        destructive:
+          'border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40',
+        outline:
+          'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+        warning: 'text-warning border-warning/60 [a&]:hover:bg-warning/20',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+)
+
+export function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<'span'> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : 'span'
+
+  return (
+    <Comp
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -14,6 +14,7 @@ export type Release = {
   isSelected: boolean
   created_at: string
   published_at: string
+  prerelease: boolean
 }
 
 export type Tag = {
@@ -79,6 +80,7 @@ export async function getRelease(repo: string, tag?: string): Promise<Release> {
     isSelected: false,
     created_at: data.created_at,
     published_at: data.published_at,
+    prerelease: data.prerelease,
   }
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [x] I have included the necessary changes to the documentation.
- [x] I have added tests to cover my changes.

## PR Type
What kind of change does this PR introduce?
- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the new behavior?
This pull request includes changes to the `ReleaseContent` component and the addition of a new `Badge` component to improve the display of release information. The most important changes include updating the UI to include a badge for pre-releases, adding a new `Badge` component, and modifying the `Release` type to include a `prerelease` property.

Changes to `ReleaseContent` component:

* [`components/ReleaseContent.tsx`](diffhunk://#diff-e193317c0a95815d6d6a39e959957193f1c613b015516d145bf2a92f55fc8610R15): Updated the UI to include a `Badge` for pre-releases and adjusted the layout of elements. [[1]](diffhunk://#diff-e193317c0a95815d6d6a39e959957193f1c613b015516d145bf2a92f55fc8610R15) [[2]](diffhunk://#diff-e193317c0a95815d6d6a39e959957193f1c613b015516d145bf2a92f55fc8610L56-R57) [[3]](diffhunk://#diff-e193317c0a95815d6d6a39e959957193f1c613b015516d145bf2a92f55fc8610L78-R87)

Addition of `Badge` component:

* [`components/ui/badge.tsx`](diffhunk://#diff-30348591d689b58233f4badf9f03beaed326c518f43e1d38187a16de9df23571R1-R44): Added a new `Badge` component with various styles and variants to be used in the `ReleaseContent` component.

Changes to `Release` type:

* [`lib/github.ts`](diffhunk://#diff-3e9b3fd031e8f78b9b5455fa3ed5f310e1e2ba9a4127b97b9e6715fed9852eefR17): Added the `prerelease` property to the `Release` type and updated the `getRelease` function to include this property. [[1]](diffhunk://#diff-3e9b3fd031e8f78b9b5455fa3ed5f310e1e2ba9a4127b97b9e6715fed9852eefR17) [[2]](diffhunk://#diff-3e9b3fd031e8f78b9b5455fa3ed5f310e1e2ba9a4127b97b9e6715fed9852eefR83)

| Before | After |
|---|---|
| ![ss-before](https://github.com/user-attachments/assets/cd6ef6da-ffe2-405b-b006-87cd668acafc) | ![ss-after](https://github.com/user-attachments/assets/abb4760a-629c-42ee-b4a4-6d8fb3a8465e) |