### PR TITLE
fix: use failureCount instead of errorUpdateCount for rate limit retry

### DIFF
--- a/components/TagList.tsx
+++ b/components/TagList.tsx
@@ -98,7 +98,7 @@ export default function TagList({
 
     // Has token: retry with countdown
     /** In seconds */
-    const waitIdleTime = 10 * (tagsQuery.errorUpdateCount || 1)
+    const waitIdleTime = 10 * (tagsQuery.failureCount || 1)
     setIdleCount(waitIdleTime)
 
     const timer = setInterval(() => {
@@ -113,7 +113,7 @@ export default function TagList({
 
     // Cleanup
     return () => clearInterval(timer)
-  }, [tagsQuery.errorUpdateCount])
+  }, [tagsQuery.failureCount])
 
   // Trigger the idle when rate limit error occurs
   useEffect(() => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
> Put `[x]` to check
- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [ ] I have included the necessary changes to the documentation.
- [ ] I have added tests to cover my changes.

## PR Type
What kind of change does this PR introduce?
> Please check any kind of changes that applies to this PR using `[x]`
- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] *..... (describe the other type)*

## What is the current behavior?
> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A (found during debugging)

The rate limit retry logic in TagList.tsx uses `errorUpdateCount` which accumulates indefinitely and never resets when the query succeeds. This causes the wait time to keep increasing permanently even after successful requests.

## What is the new behavior?
The retry logic now uses `failureCount` which properly resets to 0 when the query succeeds. This enables proper exponential backoff behavior - the wait time increases during consecutive failures but resets after a successful request.

## Other information
None