### PR TITLE
fix: dynamically whitelist Umami Analytics domain in CSP

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -21,9 +21,20 @@ const nextConfig: NextConfig = {
       connectSrc.push('ws:', 'http://localhost:*')
     }
 
+    // Build script-src directive with Umami domain if configured
+    const scriptSrc = ["'self'", "'unsafe-inline'"]
+    if (process.env.UMAMI_SCRIPT_URL) {
+      try {
+        const umamiUrl = new URL(process.env.UMAMI_SCRIPT_URL)
+        scriptSrc.push(`${umamiUrl.protocol}//${umamiUrl.host}`)
+      } catch {
+        // Invalid URL, skip adding to CSP
+      }
+    }
+
     const headerValues = [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-inline'",
+      `script-src ${scriptSrc.join(' ')}`,
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: https://avatars.githubusercontent.com",
       `connect-src ${connectSrc.join(' ')}`,


### PR DESCRIPTION
This PR fixes the Content Security Policy (CSP) blocking Umami Analytics script by dynamically whitelisting the Umami domain based on the UMAMI_SCRIPT_URL environment variable. The CSP headers added in PR #29 blocked all external scripts, which caused errors when the Umami script from PR #30 tried to load. The fix extracts the domain from UMAMI_SCRIPT_URL and adds it to the script-src directive while maintaining all existing security headers.