### PR TITLE
fix: dynamically whitelist Umami Analytics domain in CSP

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -21,9 +21,20 @@ const nextConfig: NextConfig = {
       connectSrc.push('ws:', 'http://localhost:*')
     }
 
+    // Build script-src directive with Umami domain if configured
+    const scriptSrc = ["'self'", "'unsafe-inline'"]
+    if (process.env.UMAMI_SCRIPT_URL) {
+      try {
+        const umamiUrl = new URL(process.env.UMAMI_SCRIPT_URL)
+        scriptSrc.push(`${umamiUrl.protocol}//${umamiUrl.host}`)
+      } catch {
+        // Invalid URL, skip adding to CSP
+      }
+    }
+
     const headerValues = [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-inline'",
+      `script-src ${scriptSrc.join(' ')}`,
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: https://avatars.githubusercontent.com",
       `connect-src ${connectSrc.join(' ')}`,


### PR DESCRIPTION
## PR Checklist
- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [ ] I have included the necessary changes to the documentation.
- [ ] I have added tests to cover my changes.

## PR Type
- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
PR #30 added Umami Analytics integration, but the CSP headers introduced in PR #29 block all external scripts by default. This causes CSP errors when the Umami script tries to load:
```
Loading the script 'https://stats.fityan.tech/script.js' violates the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'"
```

Issue Number: N/A

## What is the new behavior?
Dynamically extracts the protocol and host from UMAMI_SCRIPT_URL environment variable and appends it to the CSP script-src directive. This maintains existing security headers while allowing the configured analytics script to load.

## Other information
This is a fix for the CSP errors introduced after merging PR #30 (feat: add Umami analytics integration).
