### PR TITLE
fix: add Umami domain to connect-src CSP directive

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -21,12 +21,15 @@ const nextConfig: NextConfig = {
       connectSrc.push('ws:', 'http://localhost:*')
     }
 
-    // Build script-src directive with Umami domain if configured
     const scriptSrc = ["'self'", "'unsafe-inline'"]
+
+    // Add Umami domain to CSP directives if configured
     if (process.env.UMAMI_SCRIPT_URL) {
       try {
         const umamiUrl = new URL(process.env.UMAMI_SCRIPT_URL)
-        scriptSrc.push(`${umamiUrl.protocol}//${umamiUrl.host}`)
+        const umamiOrigin = `${umamiUrl.protocol}//${umamiUrl.host}`
+        scriptSrc.push(umamiOrigin)
+        connectSrc.push(umamiOrigin)
       } catch {
         // Invalid URL, skip adding to CSP
       }


### PR DESCRIPTION
## PR Checklist
- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [ ] I have included the necessary changes to the documentation.
- [ ] I have added tests to cover my changes.

## PR Type
- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
The Umami analytics script added in PR #30 loads successfully but cannot send tracking data because Content Security Policy (CSP) blocks fetch/XHR requests to the Umami API endpoint (`https://stats.fityan.tech/api/send`).

The previous fix (PR #32) only added the Umami domain to `script-src`, which allowed the script to load. However, the script also needs to make API calls to send analytics data, which requires the domain to be whitelisted in `connect-src`.

Browser console shows CSP errors:
- "connecting to 'https://stats.fityan.tech/api/send' violates the following Content Security Policy directive"
- "Fetch API cannot load... Refused to connect because it violates the document's Content Security Policy"

Issue Number: N/A (This is a follow-up fix to PR #30)

## What is the new behavior?
The Umami domain is now added to both `script-src` and `connect-src` CSP directives when `UMAMI_SCRIPT_URL` environment variable is configured.

The Umami analytics script can now:
1. Load successfully (script-src)
2. Make fetch/XHR requests to send tracking data to `/api/send` (connect-src)

The fix extracts the Umami origin once and reuses it for both directives to keep the code DRY.

## Other information
None