### PR TITLE
fix: disable nitro plugin in dev mode to prevent RSC environment conflict

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,6 @@ import { nitro } from 'nitro/vite'
 import vinext from 'vinext'
 import { defineConfig } from 'vite'
 
-export default defineConfig({
-  plugins: [vinext(), nitro()],
-})
+export default defineConfig(({ command }) => ({
+  plugins: [vinext(), command === 'build' && nitro()],
+}))


### PR DESCRIPTION
## PR Checklist
- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [ ] I have included the necessary changes to the documentation.
- [ ] I have added tests to cover my changes.

## PR Type
- [x] Bug fix

## What is the current behavior?

Running `pnpm dev` crashes with "Cannot read properties of undefined (reading 'import')" from `@vitejs/plugin-rsc` at `plugin.js:302`.

The issue occurs because Nitro's Vite plugin (`nitro:env`) auto-detects the `rsc` environment and replaces it with a `FetchableDevEnvironment` (which lacks the `runner` property that `@vitejs/plugin-rsc` expects).

## What is the new behavior?

Development server (`pnpm dev`) runs without errors. The application loads correctly in the browser.

## Other information

The fix conditionally loads the `nitro()` plugin only during build (`command === 'build'`), since Nitro is only needed for production output (`.output/`). The development server is handled by vinext itself and doesn't require the Nitro plugin.

This is a known incompatibility between `nitro@3.0.1-alpha.2` and `@vitejs/plugin-rsc@0.5.20` in dev mode. There is no upstream fix available yet as both packages are on their latest versions.