### PR TITLE
feat: migrate token storage to HttpOnly cookies with backend proxy

### DIFF
--- a/app/(main)/[username]/[repo]/error.tsx
+++ b/app/(main)/[username]/[repo]/error.tsx
@@ -8,7 +8,7 @@ import { toast } from 'sonner'
 import AddGithubTokenDialog from '@/components/AddGithubTokenDialog'
 import { Button } from '@/components/ui/button'
 import { isRateLimitError } from '@/lib/github'
-import { getStoredGithubToken } from '@/lib/tokenStorage'
+import { isGithubTokenPresent } from '@/lib/tokenStorage'
 
 export default function Error({
   error,
@@ -25,7 +25,7 @@ export default function Error({
     console.error(error)
 
     // Check if user has token
-    setHasToken(!!getStoredGithubToken())
+    setHasToken(isGithubTokenPresent())
   }, [error])
 
   const rateLimitError = isRateLimitError(error)

--- a/app/(main)/[username]/[repo]/page.client.tsx
+++ b/app/(main)/[username]/[repo]/page.client.tsx
@@ -25,6 +25,7 @@ function RepoHeader({ repo }: { repo: Repo }) {
           <Link
             href={`https://github.com/${repo.full_name}`}
             target="_blank"
+            rel="noopener noreferrer"
             className="hover:underline"
           >
             <code className="block line-clamp-2 text-ellipsis">

--- a/app/api/auth/token/route.ts
+++ b/app/api/auth/token/route.ts
@@ -1,15 +1,10 @@
 import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
-
-const TOKEN_COOKIE_NAME = 'gh_token'
-const TOKEN_EXPIRY_DAYS = 7
-
-export async function GET() {
-  const cookieStore = await cookies()
-  const hasToken = cookieStore.has(TOKEN_COOKIE_NAME)
-
-  return NextResponse.json({ authenticated: hasToken })
-}
+import {
+  AUTH_COOKIE_NAME,
+  TOKEN_COOKIE_NAME,
+  TOKEN_EXPIRY_DAYS,
+} from '@/lib/auth'
 
 export async function POST(request: Request) {
   try {
@@ -17,6 +12,13 @@ export async function POST(request: Request) {
 
     if (!token) {
       return NextResponse.json({ error: 'Token is required' }, { status: 400 })
+    }
+
+    if (!token.startsWith('github_pat_') && !token.startsWith('ghp_')) {
+      return NextResponse.json(
+        { error: 'Invalid token format' },
+        { status: 400 },
+      )
     }
 
     const cookieStore = await cookies()
@@ -35,13 +37,14 @@ export async function POST(request: Request) {
       httpOnly: true,
     })
 
-    cookieStore.set('gh_auth', 'true', {
+    cookieStore.set(AUTH_COOKIE_NAME, 'true', {
       ...commonOptions,
       httpOnly: false,
     })
 
     return NextResponse.json({ success: true })
   } catch (_error) {
+    console.error(_error)
     return NextResponse.json({ error: 'Failed to set token' }, { status: 500 })
   }
 }
@@ -49,7 +52,7 @@ export async function POST(request: Request) {
 export async function DELETE() {
   const cookieStore = await cookies()
   cookieStore.delete(TOKEN_COOKIE_NAME)
-  cookieStore.delete('gh_auth')
+  cookieStore.delete(AUTH_COOKIE_NAME)
 
   return NextResponse.json({ success: true })
 }

--- a/app/api/auth/token/route.ts
+++ b/app/api/auth/token/route.ts
@@ -1,0 +1,55 @@
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+
+const TOKEN_COOKIE_NAME = 'gh_token'
+const TOKEN_EXPIRY_DAYS = 7
+
+export async function GET() {
+  const cookieStore = await cookies()
+  const hasToken = cookieStore.has(TOKEN_COOKIE_NAME)
+
+  return NextResponse.json({ authenticated: hasToken })
+}
+
+export async function POST(request: Request) {
+  try {
+    const { token, persist } = await request.json()
+
+    if (!token) {
+      return NextResponse.json({ error: 'Token is required' }, { status: 400 })
+    }
+
+    const cookieStore = await cookies()
+
+    const commonOptions = {
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax' as const,
+      path: '/',
+      ...(persist === 'local'
+        ? { maxAge: TOKEN_EXPIRY_DAYS * 24 * 60 * 60 }
+        : {}),
+    }
+
+    cookieStore.set(TOKEN_COOKIE_NAME, token, {
+      ...commonOptions,
+      httpOnly: true,
+    })
+
+    cookieStore.set('gh_auth', 'true', {
+      ...commonOptions,
+      httpOnly: false,
+    })
+
+    return NextResponse.json({ success: true })
+  } catch (_error) {
+    return NextResponse.json({ error: 'Failed to set token' }, { status: 500 })
+  }
+}
+
+export async function DELETE() {
+  const cookieStore = await cookies()
+  cookieStore.delete(TOKEN_COOKIE_NAME)
+  cookieStore.delete('gh_auth')
+
+  return NextResponse.json({ success: true })
+}

--- a/app/api/github/[...path]/route.ts
+++ b/app/api/github/[...path]/route.ts
@@ -1,8 +1,8 @@
 import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
+import { TOKEN_COOKIE_NAME } from '@/lib/auth'
 
 const GITHUB_API_URL = 'https://api.github.com'
-const TOKEN_COOKIE_NAME = 'gh_token'
 
 export async function GET(
   request: Request,
@@ -12,6 +12,27 @@ export async function GET(
 }
 
 export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  return handleProxy(request, await params)
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  return handleProxy(request, await params)
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  return handleProxy(request, await params)
+}
+
+export async function DELETE(
   request: Request,
   { params }: { params: Promise<{ path: string[] }> },
 ) {

--- a/app/api/github/[...path]/route.ts
+++ b/app/api/github/[...path]/route.ts
@@ -1,0 +1,82 @@
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+
+const GITHUB_API_URL = 'https://api.github.com'
+const TOKEN_COOKIE_NAME = 'gh_token'
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  return handleProxy(request, await params)
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  return handleProxy(request, await params)
+}
+
+async function handleProxy(request: Request, { path }: { path: string[] }) {
+  const cookieStore = await cookies()
+  const token = cookieStore.get(TOKEN_COOKIE_NAME)?.value
+
+  const { searchParams } = new URL(request.url)
+  const targetPath = path.join('/')
+  const queryString = searchParams.toString()
+  const url = `${GITHUB_API_URL}/${targetPath}${queryString ? `?${queryString}` : ''}`
+
+  const headers = new Headers(request.headers)
+  headers.set('Accept', 'application/vnd.github+json')
+  headers.delete('host')
+  headers.delete('cookie') // Don't forward our cookies to GitHub
+
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`)
+  }
+
+  try {
+    const response = await fetch(url, {
+      method: request.method,
+      headers,
+      body:
+        request.method !== 'GET' && request.method !== 'HEAD'
+          ? await request.blob()
+          : undefined,
+    })
+
+    const data = await response.arrayBuffer()
+
+    // Create new response with forwarded headers
+    const forwardedHeaders = new Headers()
+    const headersToForward = [
+      'content-type',
+      'x-ratelimit-limit',
+      'x-ratelimit-remaining',
+      'x-ratelimit-reset',
+      'x-ratelimit-used',
+      'x-ratelimit-resource',
+      'link',
+    ]
+
+    for (const header of headersToForward) {
+      const value = response.headers.get(header)
+      if (value) {
+        forwardedHeaders.set(header, value)
+      }
+    }
+
+    return new NextResponse(data, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: forwardedHeaders,
+    })
+  } catch (error) {
+    console.error('Proxy error:', error)
+    return NextResponse.json(
+      { error: 'Failed to proxy request to GitHub' },
+      { status: 500 },
+    )
+  }
+}

--- a/components/AddGithubTokenDialog.tsx
+++ b/components/AddGithubTokenDialog.tsx
@@ -52,7 +52,7 @@ export default function AddGithubTokenDialog({
     onSubmit: async ({ value }) => {
       try {
         const trimmedToken = value.token.trim()
-        setStoredGithubToken(trimmedToken, {
+        await setStoredGithubToken(trimmedToken, {
           persist: rememberToken ? 'local' : 'session',
         })
         form.reset()
@@ -83,12 +83,12 @@ export default function AddGithubTokenDialog({
         <DialogHeader>
           <DialogTitle>Add your GitHub token</DialogTitle>
           <DialogDescription>
-            Raise your rate limit by using a personal access token. The token
-            stays on your device and is never sent to our servers.{' '}
+            Raise your rate limit by using a personal access token. The token is
+            stored securely and is only used to proxy requests to GitHub.{' '}
             <Link
               href="https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens"
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               className="underline"
             >
               Learn how to create one.

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -20,6 +20,7 @@ export function Footer() {
             <Link
               href="https://github.com/fityannugroho"
               target="_blank"
+              rel="noopener noreferrer"
               className="underline"
             >
               fityannugroho

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -19,6 +19,7 @@ type MenuItem = {
   label: string
   href: string
   target?: string
+  rel?: string
   accessories?: React.ReactNode
 }
 
@@ -27,11 +28,13 @@ const menuItems: MenuItem[] = [
     href: 'https://github.com/fityannugroho/ghrelease',
     label: 'Source Code',
     target: '_blank',
+    rel: 'noopener noreferrer',
   },
   {
     href: 'https://linktr.ee/fityannugroho',
     label: 'Support Me',
     target: '_blank',
+    rel: 'noopener noreferrer',
     accessories: <HeartHandshakeIcon className="h-5 w-5" />,
   },
 ]
@@ -62,6 +65,7 @@ export function Navbar() {
                 <Link
                   href={item.href}
                   target={item.target}
+                  rel={item.rel}
                   className="flex items-center gap-1"
                 >
                   {item.label}
@@ -95,6 +99,7 @@ export function Navbar() {
                     <Link
                       href={item.href}
                       target={item.target}
+                      rel={item.rel}
                       className="flex items-center gap-2 text-lg text-foreground/70 hover:text-foreground focus:text-foreground"
                       onClick={() => setIsOpen(false)}
                     >

--- a/components/TagList.tsx
+++ b/components/TagList.tsx
@@ -11,7 +11,7 @@ import {
   MAX_ITEMS_PER_PAGE,
   type Tag,
 } from '@/lib/github'
-import { getStoredGithubToken } from '@/lib/tokenStorage'
+import { isGithubTokenPresent } from '@/lib/tokenStorage'
 import AddGithubTokenDialog from './AddGithubTokenDialog'
 import { Button } from './ui/button'
 import { Input } from './ui/input'
@@ -87,7 +87,7 @@ export default function TagList({
 
   const triggerIdle = useCallback(() => {
     // Check if user has token
-    const hasToken = !!getStoredGithubToken()
+    const hasToken = isGithubTokenPresent()
 
     if (!hasToken) {
       // No token: disable fetching permanently

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,3 @@
+export const TOKEN_COOKIE_NAME = 'gh_token'
+export const AUTH_COOKIE_NAME = 'gh_auth'
+export const TOKEN_EXPIRY_DAYS = 7

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,5 +1,4 @@
 import { notFound } from 'next/navigation'
-import { getStoredGithubToken } from './tokenStorage'
 
 export type Repo = {
   id: number
@@ -24,7 +23,7 @@ export type Tag = {
 
 export const MAX_ITEMS_PER_PAGE = 30
 
-const GITHUB_API_URL = 'https://api.github.com'
+const GITHUB_API_URL = '/api/github'
 
 const RATE_LIMIT_ERR_MSG = 'GitHub API rate limit exceeded'
 
@@ -33,18 +32,7 @@ export function isRateLimitError(error: unknown) {
 }
 
 async function fetchGitHub<T extends object>(endpoint: string) {
-  const headers: Record<string, string> = {
-    Accept: 'application/vnd.github+json',
-  }
-
-  const token = getStoredGithubToken()
-  if (token) {
-    headers.Authorization = `Bearer ${token}`
-  }
-
-  const response = await fetch(`${GITHUB_API_URL}${endpoint}`, {
-    headers,
-  })
+  const response = await fetch(`${GITHUB_API_URL}${endpoint}`)
 
   const contentType = response.headers.get('content-type') || ''
 

--- a/lib/tokenStorage.ts
+++ b/lib/tokenStorage.ts
@@ -6,11 +6,11 @@ type StoreTokenOptions = {
 
 /**
  * Check if the user is authenticated with a GitHub token.
- * This checks for a non-HttpOnly cookie 'gh_auth'.
+ * Returns `true` if the non-HttpOnly cookie 'gh_auth' is present, `false` otherwise.
  */
-export function getStoredGithubToken(): string | null {
+export function isGithubTokenPresent(): boolean {
   if (typeof window === 'undefined') {
-    return null
+    return false
   }
 
   // We can't read the actual token (HttpOnly),
@@ -18,7 +18,7 @@ export function getStoredGithubToken(): string | null {
   const cookies = document.cookie.split('; ')
   const authCookie = cookies.find((c) => c.startsWith('gh_auth='))
 
-  return authCookie ? 'present' : null
+  return !!authCookie
 }
 
 /**
@@ -33,15 +33,21 @@ export async function setStoredGithubToken(
   }
 
   if (!token) {
-    await fetch('/api/auth/token', { method: 'DELETE' })
+    const response = await fetch('/api/auth/token', { method: 'DELETE' })
+    if (!response.ok) {
+      throw new Error('Failed to delete token')
+    }
     return
   }
 
-  await fetch('/api/auth/token', {
+  const response = await fetch('/api/auth/token', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ token, persist }),
   })
+  if (!response.ok) {
+    throw new Error('Failed to store token')
+  }
 }
 
 /**

--- a/lib/tokenStorage.ts
+++ b/lib/tokenStorage.ts
@@ -1,142 +1,30 @@
-const STORAGE_KEY = 'ghrelease.githubToken'
-const TOKEN_EXPIRY_DAYS = 7
-const TOKEN_EXPIRY_MS = TOKEN_EXPIRY_DAYS * 24 * 60 * 60 * 1000
-
-let cachedTokenData: { token: string; expiresAt?: number } | null = null
-let hasLoadedSession = false
-
-type StoredTokenData = {
-  token: string
-  expiresAt: number
-}
-
 type TokenPersistMode = 'session' | 'local'
 
 type StoreTokenOptions = {
   persist?: TokenPersistMode
 }
 
-function isTokenExpired(expiresAt: number): boolean {
-  return Date.now() > expiresAt
-}
-
-function isValidGitHubToken(value: unknown): value is string {
-  return (
-    typeof value === 'string' &&
-    value.length > 0 &&
-    (value.startsWith('github_pat_') || value.startsWith('ghp_'))
-  )
-}
-
+/**
+ * Check if the user is authenticated with a GitHub token.
+ * This checks for a non-HttpOnly cookie 'gh_auth'.
+ */
 export function getStoredGithubToken(): string | null {
   if (typeof window === 'undefined') {
     return null
   }
 
-  // Check cache expiry even if already loaded
-  if (hasLoadedSession && cachedTokenData) {
-    if (
-      cachedTokenData.expiresAt &&
-      isTokenExpired(cachedTokenData.expiresAt)
-    ) {
-      // Expired in cache - clear it
-      cachedTokenData = null
-      window.localStorage.removeItem(STORAGE_KEY)
-      window.sessionStorage.removeItem(STORAGE_KEY)
-      return null
-    }
-    return cachedTokenData.token
-  }
+  // We can't read the actual token (HttpOnly),
+  // but we can check the 'gh_auth' cookie to see if we are authenticated.
+  const cookies = document.cookie.split('; ')
+  const authCookie = cookies.find((c) => c.startsWith('gh_auth='))
 
-  if (hasLoadedSession) {
-    return cachedTokenData?.token ?? null
-  }
-
-  hasLoadedSession = true
-
-  try {
-    // Priority 1: sessionStorage (plain string)
-    const sessionValue = window.sessionStorage.getItem(STORAGE_KEY)
-    if (sessionValue) {
-      cachedTokenData = { token: sessionValue }
-      return sessionValue
-    }
-
-    // Priority 2: localStorage (JSON with expiry)
-    const localValue = window.localStorage.getItem(STORAGE_KEY)
-    if (!localValue) {
-      cachedTokenData = null
-      return null
-    }
-
-    // Try parse as JSON (new format)
-    try {
-      const parsed = JSON.parse(localValue)
-
-      // Validate structure
-      if (typeof parsed !== 'object' || parsed === null) {
-        throw new Error('Invalid token format')
-      }
-
-      if (typeof parsed.token !== 'string' || !parsed.token) {
-        throw new Error('Invalid token in storage')
-      }
-
-      // Check if has expiresAt field
-      if ('expiresAt' in parsed && typeof parsed.expiresAt === 'number') {
-        // New format with expiry
-        if (isTokenExpired(parsed.expiresAt)) {
-          // Token expired - remove and return null
-          window.localStorage.removeItem(STORAGE_KEY)
-          cachedTokenData = null
-          return null
-        }
-
-        // Token valid
-        cachedTokenData = { token: parsed.token, expiresAt: parsed.expiresAt }
-        return parsed.token
-      }
-
-      // Has token but no expiresAt - validate and add expiry
-      if (!isValidGitHubToken(parsed.token)) {
-        throw new Error('Invalid token format')
-      }
-
-      const expiresAt = Date.now() + TOKEN_EXPIRY_MS
-      window.localStorage.setItem(
-        STORAGE_KEY,
-        JSON.stringify({ token: parsed.token, expiresAt }),
-      )
-      cachedTokenData = { token: parsed.token, expiresAt }
-      return parsed.token
-    } catch {
-      // Not JSON - could be old format (plain string) or corrupt data
-      // Validate it looks like a GitHub token before migrating
-      if (!isValidGitHubToken(localValue)) {
-        // Corrupt or invalid data - clear it
-        window.localStorage.removeItem(STORAGE_KEY)
-        cachedTokenData = null
-        return null
-      }
-
-      // Valid old format - migrate
-      const expiresAt = Date.now() + TOKEN_EXPIRY_MS
-      const data: StoredTokenData = {
-        token: localValue,
-        expiresAt,
-      }
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
-      cachedTokenData = { token: localValue, expiresAt }
-      return localValue
-    }
-  } catch (error) {
-    console.error('Failed to read GitHub token from storage', error)
-    cachedTokenData = null
-    return null
-  }
+  return authCookie ? 'present' : null
 }
 
-export function setStoredGithubToken(
+/**
+ * Save a GitHub token by calling the backend API.
+ */
+export async function setStoredGithubToken(
   token: string | null,
   { persist = 'session' }: StoreTokenOptions = {},
 ) {
@@ -144,35 +32,21 @@ export function setStoredGithubToken(
     return
   }
 
-  cachedTokenData = token ? { token } : null
-  hasLoadedSession = true
-
-  try {
-    if (!token) {
-      window.sessionStorage.removeItem(STORAGE_KEY)
-      window.localStorage.removeItem(STORAGE_KEY)
-      return
-    }
-
-    if (persist === 'local') {
-      // Save to localStorage with expiry
-      const expiresAt = Date.now() + TOKEN_EXPIRY_MS
-      const data: StoredTokenData = { token, expiresAt }
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
-      cachedTokenData = { token, expiresAt }
-
-      // Remove from sessionStorage
-      window.sessionStorage.removeItem(STORAGE_KEY)
-      return
-    }
-
-    // persist === 'session'
-    // Save plain string to sessionStorage
-    window.sessionStorage.setItem(STORAGE_KEY, token)
-
-    // Remove from localStorage
-    window.localStorage.removeItem(STORAGE_KEY)
-  } catch (error) {
-    console.error('Failed to persist GitHub token', error)
+  if (!token) {
+    await fetch('/api/auth/token', { method: 'DELETE' })
+    return
   }
+
+  await fetch('/api/auth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token, persist }),
+  })
+}
+
+/**
+ * Clear the GitHub token by calling the backend API.
+ */
+export async function clearStoredGithubToken() {
+  await setStoredGithubToken(null)
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [ ] I have included the necessary changes to the documentation.
- [ ] I have added tests to cover my changes.

## PR Type
What kind of change does this PR introduce?
- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
The GitHub Personal Access Token (PAT) is currently stored in the browser's localStorage, making it vulnerable to XSS attacks. Any malicious script can access the token and make unauthorized API requests on behalf of the user.

Issue Number: N/A

## What is the new behavior?
This PR migrates token storage from client-side localStorage to a secure backend proxy architecture using HttpOnly cookies, and includes the follow-up hardening fixes from review:

- **Token Storage**: The PAT is now stored in an HttpOnly, Secure, SameSite=Lax cookie that is inaccessible to JavaScript, mitigating XSS-based token theft.
- **Auth Detection**: A companion non-HttpOnly cookie (`gh_auth`) allows the frontend to synchronously detect authentication state without exposing the actual token value.
- **Backend API**: The `/api/auth/token` endpoint now handles token set and clear operations, shares auth constants, and validates token format server-side.
- **GitHub Proxy**: The `/api/github/[...path]` catch-all route proxies GitHub API requests with the stored token and now supports `GET`, `POST`, `PUT`, `PATCH`, and `DELETE`.
- **Frontend Updates**: `tokenStorage.ts` now uses async API calls, checks request failures explicitly, and uses a boolean token-presence helper for client auth detection.
- **Security Hardening**: External links opened in a new tab now consistently use `rel="noopener noreferrer"` to prevent tabnabbing.

## Other information
All verification checks pass:
- `pnpm lint`
- `pnpm tsc --noEmit`
- `pnpm build`
- Production browser smoke test: search flow, rate-limit flow, token dialog validation, and HttpOnly cookie behavior verified
